### PR TITLE
Set HP of BuildingBlock & removed unused code

### DIFF
--- a/Pluton/Objects/BuildingPart.cs
+++ b/Pluton/Objects/BuildingPart.cs
@@ -30,7 +30,7 @@ namespace Pluton
         
         public float MaxHealth {
             get {
-                return buildingBlock.MaxHealth
+                return buildingBlock.MaxHealth();
             }
         }
 


### PR DESCRIPTION
added ability to set the health of building blocks and get MaxHealth. Removed unused code regarding ownership of blocks, which is no longer needed since ownership info is no longer saved to building blocks.
