### PR TITLE
Adding RegisterWithMultipleNames to ChatCommands

### DIFF
--- a/Pluton/Objects/ChatCommands.cs
+++ b/Pluton/Objects/ChatCommands.cs
@@ -78,6 +78,17 @@ namespace Pluton
 
             return Register(c);
         }
+        
+        public List<ChatCommand> RegisterWithMultipleNames(string[] commands, string callback, string usage, string description)
+        {
+            List<ChatCommand> chatCommands = new List<ChatCommand>();
+            foreach (string command in commands)
+            {
+                ChatCommand chatCommand = Register(command).setCallback(callback).setUsage(usage).setDescription(description);
+                chatCommands.Add(chatCommand);
+            }
+            return chatCommands;
+        }
 
         public ChatCommand Register(ChatCommand command)
         {


### PR DESCRIPTION
To allow adding commands with several names, for example :

Use /rslots or /reservedslots for a command.