### PR TITLE
Renaming WeaponThrow and UseItem to match conventions

### DIFF
--- a/Pluton.Patcher/Program.cs
+++ b/Pluton.Patcher/Program.cs
@@ -325,11 +325,11 @@ namespace Pluton.Patcher
             iLProcessor.InsertBefore(CLProject.Body.Instructions[Position], Instruction.Create(OpCodes.Ldarg_0));
         }
 
-        private static void ItemConsumed()
+        private static void ItemUsed()
         {
             TypeDefinition Item = rustAssembly.MainModule.GetType("Item");
             MethodDefinition UseItem = Item.GetMethod("UseItem");
-            MethodDefinition method = hooksClass.GetMethod("UseItem");
+            MethodDefinition method = hooksClass.GetMethod("ItemUsed");
             CloneMethod(UseItem);
 
             ILProcessor iLProcessor = UseItem.Body.GetILProcessor();
@@ -575,7 +575,7 @@ namespace Pluton.Patcher
             DoorUsePatch();
 
             ItemPickup();
-            ItemConsumed();
+            ItemUsed();
             ItemRepaired();
 
             FieldsUpdate();

--- a/Pluton.Patcher/Program.cs
+++ b/Pluton.Patcher/Program.cs
@@ -484,6 +484,19 @@ namespace Pluton.Patcher
             ilProcessor.InsertBefore(RepairItem.Body.Instructions[Position], Instruction.Create(OpCodes.Ldarg_0));
         }
 
+        private static void PlayerSyringeSelf()
+        {
+            TypeDefinition SyringeWeapon = rustAssembly.MainModule.GetType("SyringeWeapon");
+            MethodDefinition InjectedSelf = SyringeWeapon.GetMethod("InjectedSelf");
+            MethodDefinition method = hooksClass.GetMethod("PlayerSyringeSelf");
+
+            int Position = InjectedSelf.Body.Instructions.Count - 1;
+            ILProcessor iLProcessor = InjectedSelf.Body.GetILProcessor();
+            iLProcessor.InsertBefore(InjectedSelf.Body.Instructions[Position], Instruction.Create(OpCodes.Callvirt, rustAssembly.MainModule.Import(method)));
+            iLProcessor.InsertBefore(InjectedSelf.Body.Instructions[Position], Instruction.Create(OpCodes.Ldarg_1));
+            iLProcessor.InsertBefore(InjectedSelf.Body.Instructions[Position], Instruction.Create(OpCodes.Ldarg_0));
+        }
+
         private static void ServerInitPatch()
         {
             TypeDefinition servermgr = rustAssembly.MainModule.GetType("ServerMgr");
@@ -592,6 +605,7 @@ namespace Pluton.Patcher
             PlayerLoaded();
             PlayerWounded();
             PlayerAssisted();
+            PlayerSyringeSelf();
 
             NPCDiedPatch();
 

--- a/Pluton/Events/ItemUsedEvent.cs
+++ b/Pluton/Events/ItemUsedEvent.cs
@@ -2,12 +2,12 @@
 
 namespace Pluton.Events
 {
-    public class UseItemEvent : CountedInstance
+    public class ItemUsedEvent : CountedInstance
     {
         private InvItem _item;
         private int _amount;
 
-        public UseItemEvent(Item item, int amountToConsume)
+        public ItemUsedEvent(Item item, int amountToConsume)
         {
             this._item = new InvItem(item);
             this._amount = amountToConsume;

--- a/Pluton/Events/SyringeUseEvent.cs
+++ b/Pluton/Events/SyringeUseEvent.cs
@@ -1,0 +1,44 @@
+﻿using System;
+
+namespace Pluton.Events
+{
+    public class SyringeUseEvent
+    {
+        private Player _user;
+        private Player _receiver;
+        private SyringeWeapon _syringeWeapon;
+        private bool _self;
+
+        public SyringeUseEvent(SyringeWeapon sw,  BaseEntity.RPCMessage msg, bool isSelf)
+        {
+            _syringeWeapon = sw;
+            _user = new Player(sw.ownerPlayer);
+            _self = isSelf;
+
+            if (isSelf)
+                _receiver = _user;
+            else
+                _receiver = new Player(BaseNetworkable.serverEntities.Find(msg.read.UInt32()) as BasePlayer);
+        }
+
+        public Player User
+        {
+            get { return this._user; }
+        }
+
+        public Player Receiver
+        {
+            get { return this._receiver; }
+        }
+
+        public SyringeWeapon Syringe
+        {
+            get { return this._syringeWeapon; }
+        }
+
+        public bool IsSelfUsage()
+        {
+            return this._self;
+        }
+    }
+}

--- a/Pluton/Events/WeaponThrowEvent.cs
+++ b/Pluton/Events/WeaponThrowEvent.cs
@@ -1,12 +1,12 @@
 namespace Pluton.Events
 {
-    public class WeaponThrow : CountedInstance
+    public class WeaponThrowEvent : CountedInstance
     {
         private ThrownWeapon _w;
         private BaseEntity.RPCMessage _msg;
         private Player _player;
 
-        public WeaponThrow(ThrownWeapon thrownWeapon, BaseEntity.RPCMessage msg)
+        public WeaponThrowEvent(ThrownWeapon thrownWeapon, BaseEntity.RPCMessage msg)
         {
             this._msg = msg;
             this._w = thrownWeapon;

--- a/Pluton/Hooks.cs
+++ b/Pluton/Hooks.cs
@@ -78,7 +78,7 @@ namespace Pluton
 
         public static Subject<MiningQuarry> OnMining = new Subject<MiningQuarry>();
 
-        public static Subject<WeaponThrow> OnWeaponThrow = new Subject<WeaponThrow>();
+        public static Subject<WeaponThrowEvent> OnWeaponThrow = new Subject<WeaponThrowEvent>();
 
         public static Subject<ItemPickupEvent> OnItemPickup = new Subject<ItemPickupEvent>();
 
@@ -342,7 +342,7 @@ namespace Pluton
 
         public static void DoThrow(ThrownWeapon thrownWeapon, BaseEntity.RPCMessage msg)
         {
-            OnWeaponThrow.OnNext(new WeaponThrow(thrownWeapon, msg));
+            OnWeaponThrow.OnNext(new WeaponThrowEvent(thrownWeapon, msg));
         }
 
         public static void OnRocketShoot(BaseLauncher baseLauncher, BaseEntity.RPCMessage msg, BaseEntity baseEntity)

--- a/Pluton/Hooks.cs
+++ b/Pluton/Hooks.cs
@@ -72,7 +72,7 @@ namespace Pluton
 
         public static Subject<ShootEvent> OnShooting = new Subject<ShootEvent>();
 
-        public static Subject<UseItemEvent> OnUseItem = new Subject<UseItemEvent>();
+        public static Subject<ItemUsedEvent> OnItemUsed = new Subject<ItemUsedEvent>();
 
         public static Subject<RocketShootEvent> OnRocketShooting = new Subject<RocketShootEvent>();
 
@@ -330,9 +330,9 @@ namespace Pluton
             OnShooting.OnNext(new ShootEvent(baseProjectile, msg));
         }
 
-        public static void UseItem(Item item, int amountToConsume)
+        public static void ItemUsed(Item item, int amountToConsume)
         {
-            OnUseItem.OnNext(new UseItemEvent(item, amountToConsume));
+            OnItemUsed.OnNext(new ItemUsedEvent(item, amountToConsume));
         }
 
         public static void ProcessResources(MiningQuarry miningQuarry)

--- a/Pluton/Hooks.cs
+++ b/Pluton/Hooks.cs
@@ -96,6 +96,8 @@ namespace Pluton
 
         public static Subject<ItemRepairEvent> OnItemRepaired = new Subject<ItemRepairEvent>();
 
+        public static Subject<SyringeUseEvent> OnPlayerSyringeSelf = new Subject<SyringeUseEvent>();
+
         #endregion
 
 
@@ -388,6 +390,11 @@ namespace Pluton
         public static void ItemRepaired(RepairBench rb, BaseEntity.RPCMessage msg)
         {
             OnItemRepaired.OnNext(new ItemRepairEvent(rb, msg));
+        }
+
+        public static void PlayerSyringeSelf(SyringeWeapon sw, BaseEntity.RPCMessage msg)
+        {
+            OnPlayerSyringeSelf.OnNext(new SyringeUseEvent(sw, msg, true));
         }
 
         public static void CombatEntityHurt(BaseCombatEntity combatEnt, HitInfo info)

--- a/Pluton/PluginLoaders/BasePlugin.cs
+++ b/Pluton/PluginLoaders/BasePlugin.cs
@@ -618,9 +618,9 @@ namespace Pluton
 
         public IDisposable OnWeaponThrowHook;
 
-        public void OnWeaponThrow(WeaponThrow wt)
+        public void OnWeaponThrow(WeaponThrowEvent wte)
         {
-            this.Invoke("On_WeaponThrow", wt);
+            this.Invoke("On_WeaponThrow", wte);
         }
 
         public IDisposable OnItemPickupHook;

--- a/Pluton/PluginLoaders/BasePlugin.cs
+++ b/Pluton/PluginLoaders/BasePlugin.cs
@@ -595,11 +595,11 @@ namespace Pluton
             this.Invoke("On_Shooting", se);
         }
 
-        public IDisposable OnUseItemHook;
+        public IDisposable OnItemUsedHook;
 
-        public void OnUseItem(UseItemEvent uie)
+        public void OnItemUsed(ItemUsedEvent uie)
         {
-            this.Invoke("On_UseItem", uie);
+            this.Invoke("On_ItemUsed", uie);
         }
 
         public IDisposable OnRocketShootingHook;

--- a/Pluton/PluginLoaders/BasePlugin.cs
+++ b/Pluton/PluginLoaders/BasePlugin.cs
@@ -679,6 +679,13 @@ namespace Pluton
             this.Invoke("On_ItemRepaired", ire);
         }
 
+        public IDisposable OnPlayerSyringeSelfHook;
+
+        public void OnPlayerSyringeSelf(SyringeUseEvent sue)
+        {
+            this.Invoke("On_PlayerSyringeSelf", sue);
+        }
+
         public IDisposable OnServerConsoleHook;
 
         public void OnServerConsole(ServerConsoleEvent ce)

--- a/Pluton/PluginLoaders/IPlugin.cs
+++ b/Pluton/PluginLoaders/IPlugin.cs
@@ -67,7 +67,7 @@ namespace Pluton
 
         void OnMining(MiningQuarry mq);
 
-        void OnWeaponThrow(WeaponThrow wt);
+        void OnWeaponThrow(WeaponThrowEvent wte);
 
         void OnItemPickup(ItemPickupEvent ipe);
 

--- a/Pluton/PluginLoaders/IPlugin.cs
+++ b/Pluton/PluginLoaders/IPlugin.cs
@@ -91,6 +91,8 @@ namespace Pluton
 
         void OnItemRepaired(ItemRepairEvent ire);
 
+        void OnPlayerSyringeSelf(SyringeUseEvent sue);
+
         void OnTimerCB(TimedEvent evt);
     }
 

--- a/Pluton/PluginLoaders/IPlugin.cs
+++ b/Pluton/PluginLoaders/IPlugin.cs
@@ -61,7 +61,7 @@ namespace Pluton
 
         void OnShooting(ShootEvent se);
 
-        void OnUseItem(UseItemEvent uie);
+        void OnItemUsed(ItemUsedEvent uie);
 
         void OnRocketShooting(RocketShootEvent rse);
 

--- a/Pluton/PluginLoaders/PluginLoader.cs
+++ b/Pluton/PluginLoaders/PluginLoader.cs
@@ -220,8 +220,8 @@
                 case "On_Shooting":
                     plugin.OnShootingHook = Hooks.OnShooting.Subscribe(p => plugin.OnShooting(p));
                     break;
-                case "On_UseItem":
-                    plugin.OnUseItemHook = Hooks.OnUseItem.Subscribe(p => plugin.OnUseItem(p));
+                case "On_ItemUsed":
+                    plugin.OnItemUsedHook = Hooks.OnItemUsed.Subscribe(p => plugin.OnItemUsed(p));
                     break;
                 case "On_RocketShooting":
                     plugin.OnRocketShootingHook = Hooks.OnRocketShooting.Subscribe(p => plugin.OnRocketShooting(p));
@@ -368,8 +368,8 @@
                 case "On_Shooting":
                     plugin.OnShootingHook.Dispose();
                     break;
-                case "On_UseItem":
-                    plugin.OnUseItemHook.Dispose();
+                case "On_ItemUsed":
+                    plugin.OnItemUsedHook.Dispose();
                     break;
                 case "On_RocketShooting":
                     plugin.OnRocketShootingHook.Dispose();

--- a/Pluton/PluginLoaders/PluginLoader.cs
+++ b/Pluton/PluginLoaders/PluginLoader.cs
@@ -241,6 +241,9 @@
                 case "On_ItemRepaired":
                     plugin.OnItemRepairedHook = Hooks.OnItemRepaired.Subscribe(p => plugin.OnItemRepaired(p));
                     break;
+                case "On_PlayerSyringeSelf":
+                    plugin.OnPlayerSyringeSelfHook = Hooks.OnPlayerSyringeSelf.Subscribe(p => plugin.OnPlayerSyringeSelf(p));
+                    break;
                 case "On_PluginInit":
                     plugin.Invoke("On_PluginInit");
                     break;
@@ -388,6 +391,9 @@
                     break;
                 case "On_ItemRepaired":
                     plugin.OnItemRepairedHook.Dispose();
+                    break;
+                case "On_PlayerSyringeSelf":
+                    plugin.OnPlayerSyringeSelfHook.Dispose();
                     break;
                 case "On_PluginInit":
                 case "On_PluginDeinit":

--- a/Pluton/Pluton.csproj
+++ b/Pluton/Pluton.csproj
@@ -64,7 +64,7 @@
     <Compile Include="Events\ItemRepairEvent.cs" />
     <Compile Include="Events\RocketShootEvent.cs" />
     <Compile Include="Events\ShootEvent.cs" />
-    <Compile Include="Events\UseItemEvent.cs" />
+    <Compile Include="Events\ItemUsedEvent.cs" />
     <Compile Include="Events\WeaponThrowEvent.cs" />
     <Compile Include="PluginLoaders\LUAPlugin.cs" />
     <Compile Include="PluginLoaders\LUAPluginLoader.cs" />

--- a/Pluton/Pluton.csproj
+++ b/Pluton/Pluton.csproj
@@ -65,7 +65,7 @@
     <Compile Include="Events\RocketShootEvent.cs" />
     <Compile Include="Events\ShootEvent.cs" />
     <Compile Include="Events\UseItemEvent.cs" />
-    <Compile Include="Events\WeaponThrow.cs" />
+    <Compile Include="Events\WeaponThrowEvent.cs" />
     <Compile Include="PluginLoaders\LUAPlugin.cs" />
     <Compile Include="PluginLoaders\LUAPluginLoader.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/Pluton/Pluton.csproj
+++ b/Pluton/Pluton.csproj
@@ -65,6 +65,7 @@
     <Compile Include="Events\RocketShootEvent.cs" />
     <Compile Include="Events\ShootEvent.cs" />
     <Compile Include="Events\ItemUsedEvent.cs" />
+    <Compile Include="Events\SyringeUseEvent.cs" />
     <Compile Include="Events\WeaponThrowEvent.cs" />
     <Compile Include="PluginLoaders\LUAPlugin.cs" />
     <Compile Include="PluginLoaders\LUAPluginLoader.cs" />


### PR DESCRIPTION
WeaponThrow event was missing "Event" at the end and UseItem renamed to ItemUsed to match all other hooks (ItemPickup, ItemRepaired...)